### PR TITLE
[Feat] my.dart, app_theme.dart - add my page and app theme to pages

### DIFF
--- a/defeefront/lib/main.dart
+++ b/defeefront/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:defeefront/routes.dart';
 import 'package:flutter/material.dart';
 
+import 'package:defeefront/themes/app_theme.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -12,9 +14,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: "defee{ }",
-      theme: ThemeData(
-        fontFamily: "Pretendard",
-      ),
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      themeMode: ThemeMode.system,
       routes: routes,
     );
   }

--- a/defeefront/lib/routes.dart
+++ b/defeefront/lib/routes.dart
@@ -3,7 +3,6 @@ import 'package:defeefront/screens/search/search.dart';
 import 'package:defeefront/screens/search_result/search_result.dart';
 import 'package:defeefront/screens/login/login.dart';
 import 'package:defeefront/screens/signup/signup.dart';
-import 'package:defeefront/screens/post/post.dart';
 import 'package:defeefront/screens/my/my.dart';
 
 import 'package:flutter/material.dart';
@@ -15,7 +14,5 @@ final routes = {
   '/search': (BuildContext context) => Search(),
   '/searchresult': (BuildContext context) => SearchResult(),
   '/recommend': (BuildContext context) => Headline(),
-  // '/my': (BuildContext context) =>
-  //     PostPage(url: "https://pongpongi.tistory.com/47"),
-  '/my': (context) => const MyPage(),
+  '/my': (BuildContext context) => const MyPage(),
 };

--- a/defeefront/lib/routes.dart
+++ b/defeefront/lib/routes.dart
@@ -4,6 +4,7 @@ import 'package:defeefront/screens/search_result/search_result.dart';
 import 'package:defeefront/screens/login/login.dart';
 import 'package:defeefront/screens/signup/signup.dart';
 import 'package:defeefront/screens/post/post.dart';
+import 'package:defeefront/screens/my/my.dart';
 
 import 'package:flutter/material.dart';
 
@@ -14,7 +15,7 @@ final routes = {
   '/search': (BuildContext context) => Search(),
   '/searchresult': (BuildContext context) => SearchResult(),
   '/recommend': (BuildContext context) => Headline(),
-  '/my': (BuildContext context) =>
-      PostPage(url: "https://pongpongi.tistory.com/47"),
-  // '/my': (context) => const BaseScreen(child: Headline()),
+  // '/my': (BuildContext context) =>
+  //     PostPage(url: "https://pongpongi.tistory.com/47"),
+  '/my': (context) => const MyPage(),
 };

--- a/defeefront/lib/screens/headline/widgets/category.dart
+++ b/defeefront/lib/screens/headline/widgets/category.dart
@@ -11,7 +11,7 @@ class Category extends StatelessWidget {
       width: double.infinity,
       alignment: Alignment.center,
       child: DefaultTextStyle(
-        style: DefeeTextStyles.hintSmall,
+        style: DefeeTextStyles.onSurfaceSmall,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: const [

--- a/defeefront/lib/screens/headline/widgets/category.dart
+++ b/defeefront/lib/screens/headline/widgets/category.dart
@@ -1,3 +1,4 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 
 class Category extends StatelessWidget {
@@ -10,10 +11,7 @@ class Category extends StatelessWidget {
       width: double.infinity,
       alignment: Alignment.center,
       child: DefaultTextStyle(
-        style: const TextStyle(
-          fontSize: 13,
-          color: Color.fromARGB(255, 92, 92, 92),
-        ),
+        style: DefeeTextStyles.hintSmall,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: const [

--- a/defeefront/lib/screens/headline/widgets/popular.dart
+++ b/defeefront/lib/screens/headline/widgets/popular.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
 
 class Popular extends StatelessWidget {
   const Popular({super.key});
@@ -28,15 +29,15 @@ class Popular extends StatelessWidget {
           SizedBox(height: 10),
           Text(
             "재로그",
-            style: TextStyle(fontSize: 13, fontWeight: FontWeight.normal),
+            style: DefeeTextStyles.bodySmall,
           ),
           Text(
             "SOLID - SRP와 OCP",
-            style: TextStyle(fontSize: 23, fontWeight: FontWeight.normal),
+            style: DefeeTextStyles.bodyLarge,
           ),
           SizedBox(height: 10),
           Divider(
-            color: Colors.grey,
+            color: DefeeColors.grey,
             thickness: 1,
           ),
         ],

--- a/defeefront/lib/screens/headline/widgets/slide_post.dart
+++ b/defeefront/lib/screens/headline/widgets/slide_post.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
 
 class SlidePost extends StatelessWidget {
   const SlidePost({super.key});
@@ -30,7 +31,7 @@ class SlidePost extends StatelessWidget {
               backgroundColor: Color.fromARGB(1, 186, 186, 186)),
           child: const Text(
             "전체 포스트 컨텐츠",
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(color: DefeeColors.white),
           ),
         ),
         SizedBox(height: 10),
@@ -51,7 +52,7 @@ class SlideItem extends StatelessWidget {
     return Container(
         width: 380,
         margin: const EdgeInsets.only(right: 20),
-        padding: const EdgeInsets.all(16),
+        padding: DefeeThemeSizes.thickPadding,
         decoration: BoxDecoration(
           color: Color.fromARGB(139, 129, 129, 129),
           borderRadius: BorderRadius.circular(12),
@@ -64,10 +65,7 @@ class SlideItem extends StatelessWidget {
               children: [
                 Text(
                   "미새문지",
-                  style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold),
+                  style: DefeeTextStyles.onPrimaryMedium,
                 ),
                 SizedBox(width: 5),
                 Image(
@@ -78,7 +76,7 @@ class SlideItem extends StatelessWidget {
             ),
             Text(
               "소프트웨어 품질 관리",
-              style: TextStyle(fontSize: 15, color: Colors.white),
+              style: DefeeTextStyles.onPrimarySmall,
             )
           ],
         ));

--- a/defeefront/lib/screens/headline/widgets/slide_post.dart
+++ b/defeefront/lib/screens/headline/widgets/slide_post.dart
@@ -27,16 +27,17 @@ class SlidePost extends StatelessWidget {
             print("Button clicked!");
           },
           style: ElevatedButton.styleFrom(
-              minimumSize: const Size(double.infinity, 55),
-              backgroundColor: Color.fromARGB(1, 186, 186, 186)),
-          child: const Text(
+            minimumSize: const Size(double.infinity, 55),
+            backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+          ),
+          child: Text(
             "전체 포스트 컨텐츠",
-            style: TextStyle(color: DefeeColors.white),
+            style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
           ),
         ),
         SizedBox(height: 10),
         Divider(
-          color: Colors.grey,
+          color: Theme.of(context).colorScheme.outlineVariant,
           thickness: 1,
         ),
       ],
@@ -54,7 +55,7 @@ class SlideItem extends StatelessWidget {
         margin: const EdgeInsets.only(right: 20),
         padding: DefeeThemeSizes.thickPadding,
         decoration: BoxDecoration(
-          color: Color.fromARGB(139, 129, 129, 129),
+          color: Theme.of(context).colorScheme.surfaceContainer,
           borderRadius: BorderRadius.circular(12),
         ),
         alignment: Alignment.center,
@@ -65,7 +66,7 @@ class SlideItem extends StatelessWidget {
               children: [
                 Text(
                   "미새문지",
-                  style: DefeeTextStyles.onPrimaryMedium,
+                  style: DefeeTextStyles.onSurfaceMedium,
                 ),
                 SizedBox(width: 5),
                 Image(
@@ -76,7 +77,7 @@ class SlideItem extends StatelessWidget {
             ),
             Text(
               "소프트웨어 품질 관리",
-              style: DefeeTextStyles.onPrimarySmall,
+              style: DefeeTextStyles.onSurfaceSmall,
             )
           ],
         ));

--- a/defeefront/lib/screens/my/my.dart
+++ b/defeefront/lib/screens/my/my.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:defeefront/widgets/footer.dart';
 import 'package:defeefront/widgets/header.dart';
+import 'package:defeefront/screens/my/widgets/my_menu.dart';
 import 'package:defeefront/screens/my/widgets/my_floating_button.dart';
 import 'package:defeefront/screens/my/widgets/my_content.dart';
 
@@ -12,12 +13,38 @@ class MyPage extends StatefulWidget {
 }
 
 class _MyPageState extends State<MyPage> {
+  final List<MyMenuItem> _folders = [
+    MyMenuItem(title: "저장", isFolder: true),
+    MyMenuItem(title: "자료구조", isFolder: true),
+    MyMenuItem(title: "면접", isFolder: true),
+  ];
+
+  final List<String> _keywords = ["AWS", "Python", "React"];
+
+  void _addFolder(String folderName) {
+    setState(() {
+      _folders.add(MyMenuItem(title: folderName, isFolder: true));
+    });
+  }
+
+  void _addKeyword(String keyword) {
+    setState(() {
+      _keywords.add(keyword);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: Header(),
-      body: const MyContent(),
-      floatingActionButton: const MyFloatingButton(),
+      body: MyContent(
+        folders: _folders,
+        keywords: _keywords,
+      ),
+      floatingActionButton: MyFloatingButton(
+        onFolderAdded: _addFolder,
+        onKeywordAdded: _addKeyword,
+      ),
       bottomNavigationBar: Footer(),
     );
   }

--- a/defeefront/lib/screens/my/my.dart
+++ b/defeefront/lib/screens/my/my.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:defeefront/widgets/footer.dart';
 import 'package:defeefront/widgets/header.dart';
+import 'package:defeefront/screens/my/widgets/my_floating_button.dart';
 import 'package:defeefront/screens/my/widgets/my_content.dart';
 
 class MyPage extends StatefulWidget {
@@ -16,6 +17,7 @@ class _MyPageState extends State<MyPage> {
     return Scaffold(
       appBar: Header(),
       body: const MyContent(),
+      floatingActionButton: const MyFloatingButton(),
       bottomNavigationBar: Footer(),
     );
   }

--- a/defeefront/lib/screens/my/my.dart
+++ b/defeefront/lib/screens/my/my.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:defeefront/widgets/footer.dart';
+import 'package:defeefront/widgets/header.dart';
+import 'package:defeefront/screens/my/widgets/my_content.dart';
+
+class MyPage extends StatefulWidget {
+  const MyPage({Key? key}) : super(key: key);
+
+  @override
+  State<MyPage> createState() => _MyPageState();
+}
+
+class _MyPageState extends State<MyPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: Header(),
+      body: const MyContent(),
+      bottomNavigationBar: Footer(),
+    );
+  }
+}

--- a/defeefront/lib/screens/my/widgets/my_content.dart
+++ b/defeefront/lib/screens/my/widgets/my_content.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class MyContent extends StatefulWidget {
+  const MyContent({Key? key}) : super(key: key);
+
+  @override
+  State<MyContent> createState() => _MyContentState();
+}
+
+class _MyContentState extends State<MyContent> {
+  @override
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+          child: Column(
+        children: [
+          Text('My Content'),
+          Text('My Content'),
+        ],
+      )),
+    );
+  }
+}

--- a/defeefront/lib/screens/my/widgets/my_content.dart
+++ b/defeefront/lib/screens/my/widgets/my_content.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/screens/my/widgets/my_menu.dart';
+import 'package:defeefront/screens/my/widgets/my_post.dart';
 
 class MyContent extends StatefulWidget {
   const MyContent({Key? key}) : super(key: key);
@@ -9,16 +11,64 @@ class MyContent extends StatefulWidget {
 
 class _MyContentState extends State<MyContent> {
   @override
-  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-          child: Column(
-        children: [
-          Text('My Content'),
-          Text('My Content'),
-        ],
-      )),
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            MyMenu(
+              title: "스크랩",
+              items: [
+                MyMenuItem(title: "저장", isFolder: true),
+                MyMenuItem(title: "자료구조", isFolder: true),
+                MyMenuItem(title: "면접", isFolder: true),
+              ],
+              onPressed: (title, isFolder) {
+                if (isFolder) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => MyPost(folderName: title),
+                    ),
+                  );
+                } else {
+                  // 키워드 검색 로직 추가
+                  print("키워드 $title 검색 실행");
+                }
+              },
+            ),
+            SizedBox(height: 16),
+            MyMenu(
+              title: "키워드",
+              items: [
+                MyMenuItem(title: "AWS", isFolder: false),
+                MyMenuItem(title: "Python", isFolder: false),
+                MyMenuItem(title: "React", isFolder: false),
+                MyMenuItem(title: "AWS", isFolder: false),
+                MyMenuItem(title: "Python", isFolder: false),
+                MyMenuItem(title: "React", isFolder: false),
+                MyMenuItem(title: "AWS", isFolder: false),
+                MyMenuItem(title: "Python", isFolder: false),
+                MyMenuItem(title: "React", isFolder: false),
+              ],
+              onPressed: (title, isFolder) {
+                if (isFolder) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => MyPost(folderName: title),
+                    ),
+                  );
+                } else {
+                  // 키워드 검색 로직 추가
+                  print("키워드 $title 검색 실행");
+                }
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/defeefront/lib/screens/my/widgets/my_content.dart
+++ b/defeefront/lib/screens/my/widgets/my_content.dart
@@ -1,73 +1,55 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:defeefront/screens/my/widgets/my_menu.dart';
 import 'package:defeefront/screens/my/widgets/my_post.dart';
 
-class MyContent extends StatefulWidget {
-  const MyContent({Key? key}) : super(key: key);
+class MyContent extends StatelessWidget {
+  final List<MyMenuItem> folders;
+  final List<String> keywords;
 
-  @override
-  State<MyContent> createState() => _MyContentState();
-}
+  const MyContent({
+    Key? key,
+    required this.folders,
+    required this.keywords,
+  }) : super(key: key);
 
-class _MyContentState extends State<MyContent> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            MyMenu(
-              title: "스크랩",
-              items: [
-                MyMenuItem(title: "저장", isFolder: true),
-                MyMenuItem(title: "자료구조", isFolder: true),
-                MyMenuItem(title: "면접", isFolder: true),
-              ],
-              onPressed: (title, isFolder) {
-                if (isFolder) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => MyPost(folderName: title),
-                    ),
-                  );
-                } else {
-                  // 키워드 검색 로직 추가
-                  print("키워드 $title 검색 실행");
-                }
-              },
-            ),
-            SizedBox(height: 16),
-            MyMenu(
-              title: "키워드",
-              items: [
-                MyMenuItem(title: "AWS", isFolder: false),
-                MyMenuItem(title: "Python", isFolder: false),
-                MyMenuItem(title: "React", isFolder: false),
-                MyMenuItem(title: "AWS", isFolder: false),
-                MyMenuItem(title: "Python", isFolder: false),
-                MyMenuItem(title: "React", isFolder: false),
-                MyMenuItem(title: "AWS", isFolder: false),
-                MyMenuItem(title: "Python", isFolder: false),
-                MyMenuItem(title: "React", isFolder: false),
-              ],
-              onPressed: (title, isFolder) {
-                if (isFolder) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => MyPost(folderName: title),
-                    ),
-                  );
-                } else {
-                  // 키워드 검색 로직 추가
-                  print("키워드 $title 검색 실행");
-                }
-              },
-            ),
-          ],
-        ),
+    return Padding(
+      padding: DefeeThemeSizes.thickPadding,
+      child: Column(
+        children: [
+          MyMenu(
+            title: "스크랩",
+            items: folders,
+            onPressed: (title, isFolder) {
+              if (isFolder) {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MyPost(folderName: title),
+                  ),
+                );
+              }
+            },
+          ),
+          SizedBox(height: 16),
+          Divider(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            thickness: 1,
+          ),
+          MyMenu(
+            title: "키워드",
+            items: keywords
+                .map((keyword) => MyMenuItem(title: keyword, isFolder: false))
+                .toList(),
+            onPressed: (title, isFolder) {
+              if (!isFolder) {
+                print("키워드 $title 검색 실행");
+              }
+            },
+          ),
+        ],
       ),
     );
   }

--- a/defeefront/lib/screens/my/widgets/my_floating_button.dart
+++ b/defeefront/lib/screens/my/widgets/my_floating_button.dart
@@ -124,7 +124,7 @@ class _MyFloatingButtonState extends State<MyFloatingButton> {
       },
       child: Icon(
         Icons.add,
-        color: Theme.of(context).colorScheme.onPrimary,
+        color: Theme.of(context).colorScheme.onSecondary,
       ),
     );
   }

--- a/defeefront/lib/screens/my/widgets/my_floating_button.dart
+++ b/defeefront/lib/screens/my/widgets/my_floating_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class MyFloatingButton extends StatefulWidget {
+  const MyFloatingButton({super.key});
+
+  @override
+  State<MyFloatingButton> createState() => _MyFloatingButtonState();
+}
+
+class _MyFloatingButtonState extends State<MyFloatingButton> {
+  static const List<(Color?, Color? background, ShapeBorder?)> customizations =
+      <(Color?, Color?, ShapeBorder?)>[
+    (null, null, null),
+    (Colors.white, Colors.blue, null),
+  ];
+  int index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () {
+        setState(() {
+          index = (index + 1) % customizations.length;
+        });
+        print("플로팅 버튼 클릭");
+      },
+      foregroundColor: customizations[index].$1,
+      backgroundColor: customizations[index].$2,
+      shape: customizations[index].$3,
+      child: const Icon(Icons.add),
+    );
+  }
+}

--- a/defeefront/lib/screens/my/widgets/my_floating_button.dart
+++ b/defeefront/lib/screens/my/widgets/my_floating_button.dart
@@ -1,33 +1,131 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:defeefront/widgets/basic_modal.dart';
+import 'package:defeefront/widgets/float_modal.dart';
 
 class MyFloatingButton extends StatefulWidget {
-  const MyFloatingButton({super.key});
+  final Function(String) onFolderAdded;
+  final Function(String) onKeywordAdded;
+
+  const MyFloatingButton({
+    Key? key,
+    required this.onFolderAdded,
+    required this.onKeywordAdded,
+  }) : super(key: key);
+
+  void _showModal(
+    BuildContext context,
+    String title,
+    String label,
+    String hintText,
+    String buttonText,
+    Function(String) onSubmitted,
+  ) {
+    showDialog(
+        barrierDismissible: true,
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: DefeeThemeSizes.borderRadius,
+            ),
+            contentPadding: DefeeThemeSizes.thickPadding,
+            content: FloatModal(
+              title: title,
+              label: label,
+              hintText: hintText,
+              buttonText: buttonText,
+              onSubmitted: (value) {
+                onSubmitted(value);
+              },
+            ),
+          );
+        });
+  }
 
   @override
   State<MyFloatingButton> createState() => _MyFloatingButtonState();
 }
 
 class _MyFloatingButtonState extends State<MyFloatingButton> {
-  static const List<(Color?, Color? background, ShapeBorder?)> customizations =
-      <(Color?, Color?, ShapeBorder?)>[
-    (null, null, null),
-    (Colors.white, Colors.blue, null),
-  ];
-  int index = 0;
-
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton(
       onPressed: () {
-        setState(() {
-          index = (index + 1) % customizations.length;
-        });
-        print("플로팅 버튼 클릭");
+        showModalBottomSheet(
+          context: context,
+          builder: (context) {
+            return BasicModal(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.of(context).pop();
+                          widget._showModal(
+                            context,
+                            "새 폴더",
+                            "새 폴더 만들기",
+                            " 폴더 이름을 입력해주세요",
+                            "추가",
+                            widget.onFolderAdded,
+                          );
+                        },
+                        child: Row(
+                          children: const [
+                            Icon(Icons.folder),
+                            SizedBox(width: 10),
+                            Text(
+                              "폴더 추가",
+                              style: DefeeTextStyles.menuMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.of(context).pop();
+                          widget._showModal(
+                            context,
+                            "키워드 추가",
+                            "키워드",
+                            " 키워드를 입력해주세요",
+                            "추가",
+                            widget.onKeywordAdded,
+                          );
+                        },
+                        child: Row(
+                          children: const [
+                            Icon(Icons.add),
+                            SizedBox(width: 10),
+                            Text(
+                              "키워드 추가",
+                              style: DefeeTextStyles.menuMedium,
+                            ),
+                          ],
+                        ),
+                      )
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        );
       },
-      foregroundColor: customizations[index].$1,
-      backgroundColor: customizations[index].$2,
-      shape: customizations[index].$3,
-      child: const Icon(Icons.add),
+      child: Icon(
+        Icons.add,
+        color: Theme.of(context).colorScheme.onPrimary,
+      ),
     );
   }
 }

--- a/defeefront/lib/screens/my/widgets/my_menu.dart
+++ b/defeefront/lib/screens/my/widgets/my_menu.dart
@@ -1,0 +1,1 @@
+import 'package:flutter/material.dart';

--- a/defeefront/lib/screens/my/widgets/my_menu.dart
+++ b/defeefront/lib/screens/my/widgets/my_menu.dart
@@ -1,1 +1,100 @@
 import 'package:flutter/material.dart';
+
+class MyMenu extends StatelessWidget {
+  final String title;
+  final List<MyMenuItem> items;
+  final Function(String title, bool isFolder)? onPressed;
+
+  MyMenu({required this.title, required this.items, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 제목
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: Text(
+            title,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        // 아이템 그리드
+        Container(
+          decoration: BoxDecoration(
+            color: Color(0xff002686),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: GridView.builder(
+            shrinkWrap: true,
+            physics: NeverScrollableScrollPhysics(),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 5,
+              // mainAxisSpacing: 12,
+              // crossAxisSpacing: 12,
+              childAspectRatio: 1,
+            ),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return GestureDetector(
+                onTap: () {
+                  if (onPressed != null) {
+                    onPressed!(item.title, item.isFolder);
+                  }
+                },
+                child: _buildMenuItem(item),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMenuItem(MyMenuItem item) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 아이콘 또는 글자
+        Container(
+          width: 50,
+          height: 50,
+          child: Center(
+            child: item.isFolder
+                ? Icon(
+                    Icons.folder,
+                    color: Colors.white,
+                    size: 36,
+                  )
+                : Text(
+                    item.title.substring(0, 1).toUpperCase(),
+                    style: TextStyle(
+                      fontSize: 24,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+          ),
+        ),
+        Text(
+          item.title,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(fontSize: 10, color: Colors.white),
+        ),
+      ],
+    );
+  }
+}
+
+// 메뉴 아이템 모델
+class MyMenuItem {
+  final String title;
+  final bool isFolder;
+
+  MyMenuItem({required this.title, required this.isFolder});
+}

--- a/defeefront/lib/screens/my/widgets/my_menu.dart
+++ b/defeefront/lib/screens/my/widgets/my_menu.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
 
 class MyMenu extends StatelessWidget {
   final String title;
@@ -17,25 +18,18 @@ class MyMenu extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           child: Text(
             title,
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-            ),
           ),
         ),
         // 아이템 그리드
         Container(
           decoration: BoxDecoration(
-            color: Color(0xff002686),
-            borderRadius: BorderRadius.circular(10),
-          ),
+              color: Theme.of(context).colorScheme.primary,
+              borderRadius: DefeeThemeSizes.primaryBorderRadius),
           child: GridView.builder(
             shrinkWrap: true,
             physics: NeverScrollableScrollPhysics(),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 5,
-              // mainAxisSpacing: 12,
-              // crossAxisSpacing: 12,
               childAspectRatio: 1,
             ),
             itemCount: items.length,
@@ -68,23 +62,17 @@ class MyMenu extends StatelessWidget {
             child: item.isFolder
                 ? Icon(
                     Icons.folder,
-                    color: Colors.white,
+                    color: DefeeColors.white,
                     size: 36,
                   )
-                : Text(
-                    item.title.substring(0, 1).toUpperCase(),
-                    style: TextStyle(
-                      fontSize: 24,
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
+                : Text(item.title.substring(0, 1).toUpperCase(),
+                    style: DefeeTextStyles.onPrimaryLarge),
           ),
         ),
         Text(
           item.title,
           overflow: TextOverflow.ellipsis,
-          style: TextStyle(fontSize: 10, color: Colors.white),
+          style: TextStyle(fontSize: 10, color: DefeeColors.white),
         ),
       ],
     );

--- a/defeefront/lib/screens/my/widgets/my_post.dart
+++ b/defeefront/lib/screens/my/widgets/my_post.dart
@@ -1,12 +1,25 @@
 import 'package:flutter/material.dart';
 
 class MyPost extends StatelessWidget {
-  const MyPost({super.key});
+  final String folderName;
+
+  MyPost({required this.folderName});
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.center,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(folderName),
+      ),
+      body: ListView.builder(
+        itemCount: 10, // 예시 데이터
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text('이것저것 블로그'),
+            subtitle: Text('가상 메모리'),
+          );
+        },
+      ),
     );
   }
 }

--- a/defeefront/lib/screens/my/widgets/my_post.dart
+++ b/defeefront/lib/screens/my/widgets/my_post.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class MyPost extends StatelessWidget {
+  const MyPost({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+    );
+  }
+}

--- a/defeefront/lib/screens/my/widgets/my_post.dart
+++ b/defeefront/lib/screens/my/widgets/my_post.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/screens/post/post.dart';
 
 class MyPost extends StatelessWidget {
   final String folderName;
@@ -14,9 +15,19 @@ class MyPost extends StatelessWidget {
       body: ListView.builder(
         itemCount: 10, // 예시 데이터
         itemBuilder: (context, index) {
+          final postUrl = "https://pongpongi.tistory.com/$index"; // 예시 URL
           return ListTile(
-            title: Text('이것저것 블로그'),
-            subtitle: Text('가상 메모리'),
+            title: Text('가상 메모리'),
+            subtitle: Text('이것저것 블로그 $index'),
+            onTap: () {
+              // ListTile 클릭 시 PostPage로 이동
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => PostPage(url: postUrl),
+                ),
+              );
+            },
           );
         },
       ),

--- a/defeefront/lib/screens/post/widgets/post_app_bar.dart
+++ b/defeefront/lib/screens/post/widgets/post_app_bar.dart
@@ -33,14 +33,14 @@ class PostAppBar extends StatelessWidget implements PreferredSizeWidget {
               },
               child: Container(
                 padding:
-                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 6.0),
+                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
                 decoration: BoxDecoration(
-                  color: Colors.grey[300],
+                  color: Theme.of(context).colorScheme.secondary,
                   borderRadius: BorderRadius.circular(12.0),
                 ),
                 child: Text(
                   url,
-                  style: DefeeTextStyles.bodySmall,
+                  style: DefeeTextStyles.onSecondarySmall,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -128,7 +128,7 @@ class PostAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget _folderIcon(String label) {
     return Column(
       children: [
-        Icon(Icons.folder, size: 50, color: Colors.blue),
+        Icon(Icons.folder, size: 50, color: DefeeColors.blue),
         SizedBox(height: 5),
         Text(label),
       ],
@@ -137,8 +137,8 @@ class PostAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   Widget _addFolderIcon() {
     return Column(
-      children: [
-        Icon(Icons.add_circle_outline, size: 50, color: Colors.grey),
+      children: const [
+        Icon(Icons.add_circle_outline, size: 50, color: DefeeColors.grey),
         SizedBox(height: 5),
         Text("추가"),
       ],

--- a/defeefront/lib/screens/post/widgets/post_app_bar.dart
+++ b/defeefront/lib/screens/post/widgets/post_app_bar.dart
@@ -1,3 +1,4 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart'; // share_plus 패키지 추가
@@ -39,10 +40,7 @@ class PostAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ),
                 child: Text(
                   url,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    color: Colors.black,
-                  ),
+                  style: DefeeTextStyles.bodySmall,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -105,7 +103,7 @@ class PostAppBar extends StatelessWidget implements PreferredSizeWidget {
                 offset: const Offset(0, -10),
                 child: const Text(
                   'AI',
-                  style: TextStyle(fontSize: 10, color: Colors.black),
+                  style: DefeeTextStyles.bodyTiny,
                 ),
               ),
             ],

--- a/defeefront/lib/screens/post/widgets/post_navigation_bar.dart
+++ b/defeefront/lib/screens/post/widgets/post_navigation_bar.dart
@@ -10,7 +10,7 @@ class PostNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.grey[200],
+      color: Theme.of(context).colorScheme.surfaceContainer,
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/defeefront/lib/screens/search/search.dart
+++ b/defeefront/lib/screens/search/search.dart
@@ -1,4 +1,5 @@
 import 'package:defeefront/screens/search/widgets/search_history.dart';
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 import '../../widgets/footer.dart';
 import '../../widgets/header.dart';
@@ -58,19 +59,21 @@ class _SearchState extends State<Search> {
                 });
               },
               child: Container(
-                padding: EdgeInsets.all(12.0),
+                padding: DefeeThemeSizes.thickPadding,
                 decoration: BoxDecoration(
-                  color: Color(0xff002686),
-                  borderRadius: BorderRadius.circular(8.0),
+                  color: Theme.of(context).colorScheme.primary,
+                  borderRadius: DefeeThemeSizes.primaryBorderRadius,
                 ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
                       '인기 키워드',
-                      style: TextStyle(color: Colors.white),
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.onPrimary),
                     ),
-                    Icon(Icons.arrow_drop_down, color: Colors.white),
+                    Icon(Icons.arrow_drop_down,
+                        color: Theme.of(context).colorScheme.onPrimary),
                   ],
                 ),
               ),
@@ -90,11 +93,13 @@ class _SearchState extends State<Search> {
                             runSpacing: 12.0, // 칩 수직 간격
                             children: [
                               ...popularKeywords.map((keyword) {
-                                bool isSelected = selectedKeyword == keyword; // 클릭된 키워드 확인
+                                bool isSelected =
+                                    selectedKeyword == keyword; // 클릭된 키워드 확인
                                 return GestureDetector(
                                   onTap: () {
                                     // 클릭 시 검색바에 키워드 설정
-                                    searchBarKey.currentState?.setKeyword(keyword);
+                                    searchBarKey.currentState
+                                        ?.setKeyword(keyword);
                                     setState(() {
                                       selectedKeyword = keyword; // 선택된 키워드 업데이트
                                     });
@@ -102,15 +107,21 @@ class _SearchState extends State<Search> {
                                   child: Chip(
                                     label: Text(
                                       keyword,
-                                      style: TextStyle(
-                                          color: Colors.white, fontSize: 18.0),
+                                      style: DefeeTextStyles.onSurfaceSmall,
                                     ),
                                     padding: EdgeInsets.symmetric(
                                         horizontal: 12.0,
                                         vertical: 10.0), // 패딩 조정
-                                    backgroundColor: isSelected? Color(0xff002686) : Color(0xffBABABA), // 칩 배경색
+                                    backgroundColor: isSelected
+                                        ? Theme.of(context)
+                                            .colorScheme
+                                            .secondary
+                                        : Theme.of(context)
+                                            .colorScheme
+                                            .surfaceContainer, // 칩 배경색
                                     shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(15.0),
+                                      borderRadius:
+                                          DefeeThemeSizes.chipBorderRadius,
                                       // 모서리 둥글게
                                       side: BorderSide.none, // 외곽선 제거
                                     ),
@@ -118,12 +129,14 @@ class _SearchState extends State<Search> {
                                 );
                               }).toList(),
                               IconButton(
-                                icon: Icon(Icons.add, color: Color(0xff002686)),
+                                icon: Icon(Icons.add,
+                                    color:
+                                        Theme.of(context).colorScheme.primary),
                                 // '+' 아이콘
                                 onPressed: () {
                                   // TODO: '+' 아이콘 클릭
                                 },
-                                color: Color(0xff002686),
+                                color: Theme.of(context).colorScheme.primary,
                                 // 아이콘 배경색
                                 padding: EdgeInsets.symmetric(
                                     horizontal: 16.0, vertical: 10.0),
@@ -148,19 +161,20 @@ class _SearchState extends State<Search> {
                 });
               },
               child: Container(
-                padding: EdgeInsets.all(12.0),
+                padding: DefeeThemeSizes.thickPadding,
                 decoration: BoxDecoration(
-                  color: Color(0xff002686),
-                  borderRadius: BorderRadius.circular(8.0),
+                  color: Theme.of(context).colorScheme.primary,
+                  borderRadius: DefeeThemeSizes.primaryBorderRadius,
                 ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
                       '내 키워드',
-                      style: TextStyle(color: Colors.white),
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.onPrimary),
                     ),
-                    Icon(Icons.arrow_drop_down, color: Colors.white),
+                    Icon(Icons.arrow_drop_down, color: DefeeColors.white),
                   ],
                 ),
               ),
@@ -189,15 +203,17 @@ class _SearchState extends State<Search> {
                                   child: Chip(
                                     label: Text(
                                       keyword,
-                                      style: TextStyle(
-                                          color: Colors.white, fontSize: 18.0),
+                                      style: DefeeTextStyles.onSurfaceSmall,
                                     ),
                                     padding: EdgeInsets.symmetric(
                                         horizontal: 12.0,
                                         vertical: 10.0), // 패딩 조정
-                                    backgroundColor: Color(0xffBABABA), // 칩 배경색
+                                    backgroundColor: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceContainer, // 칩 배경색
                                     shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(15.0),
+                                      borderRadius:
+                                          DefeeThemeSizes.chipBorderRadius,
                                       // 모서리 둥글게
                                       side: BorderSide.none, // 외곽선 제거
                                     ),

--- a/defeefront/lib/themes/app_theme.dart
+++ b/defeefront/lib/themes/app_theme.dart
@@ -1,19 +1,25 @@
 import 'package:flutter/material.dart';
 
-class DefeeThemeColors {
-  static const Color primary = Color(0xff002686);
-  static const Color secondary = Color(0xff85A0E4);
-  static const Color background = Color(0xffffffff);
-  static const Color disabled = Color(0xffBABABA);
-  static const Color text = Color(0xff212121);
+// colors
+class DefeeColors {
+  static const blue = Color(0xff002686);
+  static const white = Color(0xffffffff);
+  static const black = Color(0xff000000);
+  static const lightBlue = Color(0xff85A0E4);
+  static const grey = Color(0xffBABABA);
+  static const blackopacity = Color(0x44000000);
+  static const red = Color(0xffFF0000);
 }
 
+// sizes
 class DefeeThemeSizes {
   // Border radius constants
   static const double borderRadiusValue = 20.0;
   static BorderRadiusGeometry get borderRadius =>
       BorderRadius.circular(borderRadiusValue);
   static Radius get radius => Radius.circular(borderRadiusValue);
+  static BorderRadiusGeometry get primaryBorderRadius =>
+      BorderRadius.circular(borderRadiusValue / 2);
 
   // Padding constants
   static const double padding = 8.0;
@@ -25,77 +31,101 @@ class DefeeThemeSizes {
   static EdgeInsets get marginInsets => EdgeInsets.all(margin);
 }
 
+// text styles
 class DefeeTextStyles {
   static const TextStyle bodySmall = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 14,
-    color: DefeeThemeColors.text,
+    color: DefeeColors.black,
   );
 
   static const TextStyle bodyMedium = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 18,
-    color: DefeeThemeColors.text,
+    color: DefeeColors.black,
   );
 
   static const TextStyle bodyLarge = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 22,
-    color: DefeeThemeColors.text,
+    color: DefeeColors.black,
+  );
+
+  static const TextStyle onPrimaryLarge = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 22,
+    color: DefeeColors.white,
   );
 
   static const TextStyle titleMedium = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 24,
     fontWeight: FontWeight.bold,
-    color: DefeeThemeColors.primary,
+    color: DefeeColors.blue,
+  );
+
+  static const TextStyle menuMedium = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 20,
+    color: DefeeColors.black,
+  );
+
+  static const TextStyle hint = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 14,
+    color: DefeeColors.grey,
   );
 }
 
+// themes
 class AppTheme {
-  static ThemeData lightTheme = ThemeData(
-    primarySwatch: Colors.blue,
-    textTheme: TextTheme(
-      bodySmall: DefeeTextStyles.bodySmall,
-      bodyMedium: DefeeTextStyles.bodyMedium,
-      bodyLarge: DefeeTextStyles.bodyLarge,
-      titleMedium: DefeeTextStyles.titleMedium,
-    ),
-    appBarTheme: AppBarTheme(
-      backgroundColor: DefeeThemeColors.background,
-      titleTextStyle: DefeeTextStyles.titleMedium,
-    ),
-    scaffoldBackgroundColor: DefeeThemeColors.background,
-    floatingActionButtonTheme: FloatingActionButtonThemeData(
-      backgroundColor: DefeeThemeColors.secondary,
-      splashColor: DefeeThemeColors.primary,
-      hoverColor: DefeeThemeColors.primary,
-    ),
-    bottomSheetTheme: BottomSheetThemeData(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-          top: DefeeThemeSizes.radius,
+  static ThemeData lightTheme = themeData(lightColorScheme);
+
+  static ThemeData themeData(ColorScheme colorScheme) {
+    return ThemeData(
+      colorScheme: colorScheme,
+      textTheme: TextTheme(
+        bodySmall: DefeeTextStyles.bodySmall,
+        bodyMedium: DefeeTextStyles.bodyMedium,
+        bodyLarge: DefeeTextStyles.bodyLarge,
+        titleMedium: DefeeTextStyles.titleMedium,
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        titleTextStyle: DefeeTextStyles.titleMedium,
+      ),
+      scaffoldBackgroundColor: colorScheme.surface,
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: colorScheme.secondary,
+        splashColor: colorScheme.primary,
+        hoverColor: colorScheme.primary,
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(
+            top: DefeeThemeSizes.radius,
+          ),
+        ),
+        modalBackgroundColor: colorScheme.surface,
+        modalBarrierColor: colorScheme.surfaceDim,
+      ),
+      dialogTheme: DialogTheme(
+        shape: RoundedRectangleBorder(
+          borderRadius: DefeeThemeSizes.borderRadius,
+        ),
+        barrierColor: colorScheme.surfaceDim,
+        backgroundColor: colorScheme.surface,
+        titleTextStyle: DefeeTextStyles.bodyMedium,
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: colorScheme.onSurface,
+          overlayColor: colorScheme.secondary,
+          padding: EdgeInsets.symmetric(vertical: 16),
         ),
       ),
-      modalBackgroundColor: DefeeThemeColors.background,
-      modalBarrierColor: Colors.black.withOpacity(0.5),
-    ),
-    dialogTheme: DialogTheme(
-      shape: RoundedRectangleBorder(
-        borderRadius: DefeeThemeSizes.borderRadius,
-      ),
-      barrierColor: Colors.black.withOpacity(0.5),
-      backgroundColor: DefeeThemeColors.background,
-      titleTextStyle: DefeeTextStyles.bodyMedium,
-    ),
-    textButtonTheme: TextButtonThemeData(
-      style: TextButton.styleFrom(
-        foregroundColor: DefeeThemeColors.text,
-        overlayColor: DefeeThemeColors.secondary,
-        padding: EdgeInsets.symmetric(vertical: 16),
-      ),
-    ),
-  );
+    );
+  }
 
   static ThemeData darkTheme = ThemeData(
     primarySwatch: Colors.blueGrey,
@@ -116,5 +146,19 @@ class AppTheme {
         color: Colors.white,
       ),
     ),
+  );
+
+  static const ColorScheme lightColorScheme = ColorScheme(
+    primary: DefeeColors.blue,
+    onPrimary: DefeeColors.white,
+    secondary: DefeeColors.lightBlue,
+    onSecondary: DefeeColors.white,
+    surface: DefeeColors.white,
+    onSurface: DefeeColors.black,
+    onSurfaceVariant: DefeeColors.grey,
+    error: DefeeColors.red,
+    onError: DefeeColors.white,
+    surfaceDim: DefeeColors.blackopacity,
+    brightness: Brightness.light,
   );
 }

--- a/defeefront/lib/themes/app_theme.dart
+++ b/defeefront/lib/themes/app_theme.dart
@@ -7,6 +7,7 @@ class DefeeColors {
   static const black = Color(0xff000000);
   static const lightBlue = Color(0xff85A0E4);
   static const grey = Color(0xffBABABA);
+  static const surfaceContainerGrey = Color(0xff646464);
   static const blackopacity = Color(0x44000000);
   static const red = Color(0xffFF0000);
 }
@@ -33,6 +34,11 @@ class DefeeThemeSizes {
 
 // text styles
 class DefeeTextStyles {
+  static const TextStyle bodyTiny = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 10,
+    color: DefeeColors.black,
+  );
   static const TextStyle bodySmall = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 14,
@@ -49,6 +55,18 @@ class DefeeTextStyles {
     fontFamily: "Pretendard",
     fontSize: 22,
     color: DefeeColors.black,
+  );
+
+  static const TextStyle onPrimarySmall = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 18,
+    color: DefeeColors.white,
+  );
+
+  static const TextStyle onPrimaryMedium = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 20,
+    color: DefeeColors.white,
   );
 
   static const TextStyle onPrimaryLarge = TextStyle(
@@ -72,8 +90,14 @@ class DefeeTextStyles {
 
   static const TextStyle hint = TextStyle(
     fontFamily: "Pretendard",
-    fontSize: 14,
+    fontSize: 18,
     color: DefeeColors.grey,
+  );
+
+  static const TextStyle hintSmall = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 14,
+    color: DefeeColors.surfaceContainerGrey,
   );
 }
 
@@ -153,7 +177,10 @@ class AppTheme {
     onPrimary: DefeeColors.white,
     secondary: DefeeColors.lightBlue,
     onSecondary: DefeeColors.white,
+    secondaryContainer: DefeeColors.grey,
+    onSecondaryContainer: DefeeColors.white,
     surface: DefeeColors.white,
+    surfaceContainer: DefeeColors.surfaceContainerGrey,
     onSurface: DefeeColors.black,
     onSurfaceVariant: DefeeColors.grey,
     error: DefeeColors.red,

--- a/defeefront/lib/themes/app_theme.dart
+++ b/defeefront/lib/themes/app_theme.dart
@@ -5,11 +5,10 @@ class DefeeColors {
   static const blue = Color(0xff002686);
   static const white = Color(0xffffffff);
   static const black = Color(0xff000000);
-  static const lightBlue = Color(0xff85A0E4);
+  static const lightBlue = Color(0xff8B8FA8);
   static const grey = Color(0xffBABABA);
-  static const surfaceContainerGrey = Color(0xff646464);
-  static const blackopacity = Color(0x44000000);
-  static const red = Color(0xffFF0000);
+  static const surfaceContainerGrey = Color(0xffeeedf5);
+  static const red = Color(0xffba1a1a);
 }
 
 // sizes
@@ -18,9 +17,12 @@ class DefeeThemeSizes {
   static const double borderRadiusValue = 20.0;
   static BorderRadiusGeometry get borderRadius =>
       BorderRadius.circular(borderRadiusValue);
-  static Radius get radius => Radius.circular(borderRadiusValue);
   static BorderRadiusGeometry get primaryBorderRadius =>
       BorderRadius.circular(borderRadiusValue / 2);
+  static BorderRadiusGeometry get chipBorderRadius =>
+      BorderRadius.circular(borderRadiusValue * 2);
+
+  static Radius get radius => Radius.circular(borderRadiusValue);
 
   // Padding constants
   static const double padding = 8.0;
@@ -59,7 +61,7 @@ class DefeeTextStyles {
 
   static const TextStyle onPrimarySmall = TextStyle(
     fontFamily: "Pretendard",
-    fontSize: 18,
+    fontSize: 14,
     color: DefeeColors.white,
   );
 
@@ -72,6 +74,30 @@ class DefeeTextStyles {
   static const TextStyle onPrimaryLarge = TextStyle(
     fontFamily: "Pretendard",
     fontSize: 22,
+    color: DefeeColors.white,
+  );
+
+  static const TextStyle onSurfaceSmall = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 14,
+    color: Color(0xff1a1b21),
+  );
+
+  static const TextStyle onSurfaceMedium = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 20,
+    color: Color(0xff1a1b21),
+  );
+
+  static const TextStyle onSurfaceLarge = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 22,
+    color: Color(0xff1a1b21),
+  );
+
+  static const TextStyle onSecondarySmall = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 14,
     color: DefeeColors.white,
   );
 
@@ -115,7 +141,7 @@ class AppTheme {
         titleMedium: DefeeTextStyles.titleMedium,
       ),
       appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
+        backgroundColor: colorScheme.surfaceContainer,
         titleTextStyle: DefeeTextStyles.titleMedium,
       ),
       scaffoldBackgroundColor: colorScheme.surface,
@@ -177,15 +203,16 @@ class AppTheme {
     onPrimary: DefeeColors.white,
     secondary: DefeeColors.lightBlue,
     onSecondary: DefeeColors.white,
-    secondaryContainer: DefeeColors.grey,
-    onSecondaryContainer: DefeeColors.white,
-    surface: DefeeColors.white,
-    surfaceContainer: DefeeColors.surfaceContainerGrey,
-    onSurface: DefeeColors.black,
-    onSurfaceVariant: DefeeColors.grey,
+    secondaryContainer: Color(0xffd1d8ff),
+    onSecondaryContainer: Color(0xff384165),
+    surface: Color(0xfffbf8ff),
+    surfaceContainer: Color(0xffeeedf5),
+    onSurface: Color(0xff1a1b21),
     error: DefeeColors.red,
     onError: DefeeColors.white,
-    surfaceDim: DefeeColors.blackopacity,
+    surfaceDim: Color(0x44121319),
+    outline: Color(0xff757683),
+    outlineVariant: Color(0xffc5c5d4),
     brightness: Brightness.light,
   );
 }

--- a/defeefront/lib/themes/app_theme.dart
+++ b/defeefront/lib/themes/app_theme.dart
@@ -8,10 +8,21 @@ class DefeeThemeColors {
   static const Color text = Color(0xff212121);
 }
 
-class DefeeThemeSizes<double> {
-  static const borderRadius = 20.0;
-  static const padding = 8.0;
-  static const margin = 8.0;
+class DefeeThemeSizes {
+  // Border radius constants
+  static const double borderRadiusValue = 20.0;
+  static BorderRadiusGeometry get borderRadius =>
+      BorderRadius.circular(borderRadiusValue);
+  static Radius get radius => Radius.circular(borderRadiusValue);
+
+  // Padding constants
+  static const double padding = 8.0;
+  static EdgeInsets get thinPadding => EdgeInsets.all(padding);
+  static EdgeInsets get thickPadding => EdgeInsets.all(padding * 2);
+
+  // Margin constants
+  static const double margin = 8.0;
+  static EdgeInsets get marginInsets => EdgeInsets.all(margin);
 }
 
 class DefeeTextStyles {
@@ -63,7 +74,7 @@ class AppTheme {
     bottomSheetTheme: BottomSheetThemeData(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(
-          top: Radius.circular(DefeeThemeSizes.borderRadius),
+          top: DefeeThemeSizes.radius,
         ),
       ),
       modalBackgroundColor: DefeeThemeColors.background,
@@ -71,7 +82,7 @@ class AppTheme {
     ),
     dialogTheme: DialogTheme(
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(DefeeThemeSizes.borderRadius),
+        borderRadius: DefeeThemeSizes.borderRadius,
       ),
       barrierColor: Colors.black.withOpacity(0.5),
       backgroundColor: DefeeThemeColors.background,

--- a/defeefront/lib/themes/app_theme.dart
+++ b/defeefront/lib/themes/app_theme.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class DefeeThemeColors {
+  static const Color primary = Color(0xff002686);
+  static const Color secondary = Color(0xff85A0E4);
+  static const Color background = Color(0xffffffff);
+  static const Color disabled = Color(0xffBABABA);
+  static const Color text = Color(0xff212121);
+}
+
+class DefeeThemeSizes<double> {
+  static const borderRadius = 20.0;
+  static const padding = 8.0;
+  static const margin = 8.0;
+}
+
+class DefeeTextStyles {
+  static const TextStyle bodySmall = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 14,
+    color: DefeeThemeColors.text,
+  );
+
+  static const TextStyle bodyMedium = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 18,
+    color: DefeeThemeColors.text,
+  );
+
+  static const TextStyle bodyLarge = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 22,
+    color: DefeeThemeColors.text,
+  );
+
+  static const TextStyle titleMedium = TextStyle(
+    fontFamily: "Pretendard",
+    fontSize: 24,
+    fontWeight: FontWeight.bold,
+    color: DefeeThemeColors.primary,
+  );
+}
+
+class AppTheme {
+  static ThemeData lightTheme = ThemeData(
+    primarySwatch: Colors.blue,
+    textTheme: TextTheme(
+      bodySmall: DefeeTextStyles.bodySmall,
+      bodyMedium: DefeeTextStyles.bodyMedium,
+      bodyLarge: DefeeTextStyles.bodyLarge,
+      titleMedium: DefeeTextStyles.titleMedium,
+    ),
+    appBarTheme: AppBarTheme(
+      backgroundColor: DefeeThemeColors.background,
+      titleTextStyle: DefeeTextStyles.titleMedium,
+    ),
+    scaffoldBackgroundColor: DefeeThemeColors.background,
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: DefeeThemeColors.secondary,
+      splashColor: DefeeThemeColors.primary,
+      hoverColor: DefeeThemeColors.primary,
+    ),
+    bottomSheetTheme: BottomSheetThemeData(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(DefeeThemeSizes.borderRadius),
+        ),
+      ),
+      modalBackgroundColor: DefeeThemeColors.background,
+      modalBarrierColor: Colors.black.withOpacity(0.5),
+    ),
+    dialogTheme: DialogTheme(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(DefeeThemeSizes.borderRadius),
+      ),
+      barrierColor: Colors.black.withOpacity(0.5),
+      backgroundColor: DefeeThemeColors.background,
+      titleTextStyle: DefeeTextStyles.bodyMedium,
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+        foregroundColor: DefeeThemeColors.text,
+        overlayColor: DefeeThemeColors.secondary,
+        padding: EdgeInsets.symmetric(vertical: 16),
+      ),
+    ),
+  );
+
+  static ThemeData darkTheme = ThemeData(
+    primarySwatch: Colors.blueGrey,
+    textTheme: TextTheme(
+      bodySmall: TextStyle(
+        fontFamily: "Pretendard",
+        fontSize: 14,
+        color: Colors.white,
+      ),
+      bodyMedium: TextStyle(
+        fontFamily: "Pretendard",
+        fontSize: 18,
+        color: Colors.white,
+      ),
+      bodyLarge: TextStyle(
+        fontFamily: "Pretendard",
+        fontSize: 22,
+        color: Colors.white,
+      ),
+    ),
+  );
+}

--- a/defeefront/lib/widgets/basic_modal.dart
+++ b/defeefront/lib/widgets/basic_modal.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 
 class BasicModal extends StatelessWidget {
   final Widget child; // Modal 내부에 표시할 위젯
-  final String title; // Modal 상단에 표시할 제목
+  final String? title; // Modal 상단에 표시할 제목
 
   const BasicModal({
     Key? key,
     required this.child,
-    required this.title,
+    this.title,
   }) : super(key: key);
 
   @override
@@ -23,26 +23,14 @@ class BasicModal extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            title,
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
-          SizedBox(height: 20),
-          child, // 부모 위젯에서 전달한 내용을 표시
-          SizedBox(height: 20),
-          Center(
-            child: ElevatedButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: Text("닫기"),
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-              ),
+          if (title != null && title!.isNotEmpty)
+            Text(
+              title!,
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
-          ),
+          SizedBox(height: 40),
+          SizedBox(height: 100, child: child),
+          SizedBox(height: 40),
         ],
       ),
     );

--- a/defeefront/lib/widgets/basic_modal.dart
+++ b/defeefront/lib/widgets/basic_modal.dart
@@ -1,3 +1,4 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 
 class BasicModal extends StatelessWidget {
@@ -26,7 +27,7 @@ class BasicModal extends StatelessWidget {
           if (title != null && title!.isNotEmpty)
             Text(
               title!,
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              style: DefeeTextStyles.bodyMedium,
             ),
           SizedBox(height: 40),
           SizedBox(height: 100, child: child),

--- a/defeefront/lib/widgets/float_modal.dart
+++ b/defeefront/lib/widgets/float_modal.dart
@@ -1,0 +1,70 @@
+import 'package:defeefront/themes/app_theme.dart';
+import 'package:flutter/material.dart';
+
+class FloatModal extends StatelessWidget {
+  final String title; // 모달 제목
+  final String label; // 입력 필드 레이블
+  final String hintText; // 입력 필드 힌트
+  final String buttonText; // 버튼 텍스트
+  final void Function(String) onSubmitted; // 완료 버튼 클릭 시 콜백
+  final TextEditingController? controller; // 외부에서 제공할 입력 컨트롤러 (옵션)
+
+  const FloatModal({
+    Key? key,
+    required this.title,
+    required this.label,
+    required this.hintText,
+    required this.buttonText,
+    required this.onSubmitted,
+    this.controller,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController _controller =
+        controller ?? TextEditingController();
+
+    return Padding(
+      padding: DefeeThemeSizes.thinPadding,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            title,
+          ),
+          SizedBox(
+            height: 10,
+          ),
+          TextField(
+            controller: _controller,
+            decoration: InputDecoration(
+              enabledBorder: UnderlineInputBorder(
+                borderSide:
+                    BorderSide(color: Theme.of(context).colorScheme.primary),
+              ),
+              focusedBorder: UnderlineInputBorder(
+                borderSide:
+                    BorderSide(color: Theme.of(context).colorScheme.primary),
+              ),
+              hintStyle: DefeeTextStyles.hint,
+              hintText: hintText,
+            ),
+            cursorColor: Theme.of(context).colorScheme.primary,
+          ),
+          SizedBox(height: 10),
+          TextButton(
+            onPressed: () {
+              final inputText = _controller.text.trim();
+              if (inputText.isNotEmpty) {
+                onSubmitted(inputText);
+                Navigator.pop(context); // 모달 닫기
+              }
+            },
+            child: Text(buttonText),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/defeefront/lib/widgets/footer.dart
+++ b/defeefront/lib/widgets/footer.dart
@@ -1,3 +1,4 @@
+import 'package:defeefront/themes/app_theme.dart';
 import 'package:flutter/material.dart';
 
 class Footer extends StatelessWidget {
@@ -66,11 +67,11 @@ class Footer extends StatelessWidget {
           return GestureDetector(
             onTap: () => Navigator.pushNamed(context, route),
             child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 25),
+              padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 25),
               decoration: isActive
                   ? BoxDecoration(
-                      borderRadius: BorderRadius.circular(25),
-                      color: Theme.of(context).colorScheme.secondaryContainer,
+                      borderRadius: DefeeThemeSizes.borderRadius,
+                      color: Theme.of(context).colorScheme.secondary,
                     )
                   : null,
               child: Column(
@@ -79,14 +80,18 @@ class Footer extends StatelessWidget {
                   Icon(
                     icon,
                     size: 28,
-                    color: isActive ? Colors.white : Colors.white70,
+                    color: isActive
+                        ? Theme.of(context).colorScheme.onSecondary
+                        : Theme.of(context).colorScheme.onSurface,
                   ),
                   const SizedBox(height: 4),
                   Text(
                     label,
                     style: TextStyle(
                       fontSize: 14,
-                      color: isActive ? Colors.white : Colors.white70,
+                      color: isActive
+                          ? Theme.of(context).colorScheme.onSecondary
+                          : Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                 ],

--- a/defeefront/lib/widgets/footer.dart
+++ b/defeefront/lib/widgets/footer.dart
@@ -8,7 +8,7 @@ class Footer extends StatelessWidget {
     final String? currentRoute = ModalRoute.of(context)?.settings.name;
 
     return Container(
-      color: Colors.grey[850],
+      color: Theme.of(context).colorScheme.surfaceContainer,
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -70,7 +70,7 @@ class Footer extends StatelessWidget {
               decoration: isActive
                   ? BoxDecoration(
                       borderRadius: BorderRadius.circular(25),
-                      color: Colors.white38,
+                      color: Theme.of(context).colorScheme.secondaryContainer,
                     )
                   : null,
               child: Column(
@@ -78,7 +78,7 @@ class Footer extends StatelessWidget {
                 children: [
                   Icon(
                     icon,
-                    size: 20,
+                    size: 28,
                     color: isActive ? Colors.white : Colors.white70,
                   ),
                   const SizedBox(height: 4),

--- a/defeefront/lib/widgets/header.dart
+++ b/defeefront/lib/widgets/header.dart
@@ -10,7 +10,7 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
       leading: IconButton(
         icon: Icon(
           Icons.arrow_back_ios_new,
-          color: Colors.indigo[900],
+          color: Theme.of(context).colorScheme.primary,
           size: 24,
         ),
         onPressed: () {
@@ -19,10 +19,6 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
       ),
       title: Text(
         "헤드라인",
-        style: TextStyle(
-            color: Colors.indigo[900],
-            fontWeight: FontWeight.bold,
-            fontSize: 24),
       ),
     );
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

#13 

## 📝작업 내용

### `my.dart` 구현
`my.dart`는 `Header`와 `Footer`를 포함하여 `MyContent`와 `MyFloatingButton`를 Scaffold를 사용하여 레이아웃을 만들고 있습니다.

#### `my_content`
두 개의 `MyMenu`로 이뤄진 Column입니다. 푸터와 헤더를 제외한 컨텐츠들이 보여질 공간으로, 스크랩 추가 혹은 키워드 추가가 가능합니다.

#### `my_floating_button`
`FloatingActionButton`을 활용하여 액션 버튼을 구현하였습니다.
`onTap()`시에 처음 나오는 모달은 `showModalBottomSheet`를 활용하였고, 이후 각각의 메뉴를 눌러서 나오는 dialog는 `showDialog`를 사용하였습니다. `AlertDialog` 위젯을 활용하여 보여지고, 안의 내용은 `FloatModal`이라는 공용 위젯으로 만들었습니다. **이는 위젯명 수정이 필요해 보입니다.**

#### `my_menu`
`GridView`를 활용하여 스크랩 폴더와 키워드들의 view를 구현하였습니다. `onTap()`시에 `my_post.dart`로 넘어갑니다.

#### `my_post`
`ListView`를 활용하여 스크랩한 페이지들의 간단한 표시를 가능하게 만들었습니다. 리스트 뷰, 이미지 뷰 등 목록화를 추가적으로 제공하는 기능을 보완할 수 있습니다.

### `app_theme.dart`구현
**defee**의 theme을 등록하였습니다. 이에 여태 merge 되었던 페이지들에 대한 여러 값들도 theme에 맞게 수정하였습니다.

사용법 및 자세한 사항은 추가사항에서 더 설명하겠습니다.

## 💡 추가사항
### 보완사항
- `FloatModal`이라는 공용 위젯에 대한 위젯명 수정
- `my_post` image post view, list view 구현

### app_theme 사용하는법
기존에 `Color`, `TextStyle` 등의 사용이 너무 불편하고  통일되지 못해서 유지보수에 어려움이 있어서 이를 하나로 관리할 수 있는 app_theme.dart를 만들었습니다.

디자인은 material design을 참고하였으며, 추가된 theme들은 다음과 같습니다.
#### 1. DefeeColors 클래스
앱에서 사용하는 색상 상수를 정의한 클래스입니다. 앱 전체에서 일관된 색상을 사용하기 위해 사용됩니다.

- 사용법:
  원하는 색상 코드를 직접 호출하여 사용합니다.
```dart
Container(
  color: DefeeColors.blue,
  child: Text('Blue Background', style: TextStyle(color: DefeeColors.white)),
);
```
- 주요 색상:
  - blue: 기본 파란색 (#002686)
  - white: 흰색 (#FFFFFF)
  - black: 검은색 (#000000)
  - lightBlue: 연한 파란색 (#8B8FA8)
  - grey: 회색 (#BABABA)
  - surfaceContainerGrey: 밝은 회색 (#EEEDF5)
  - red: 빨간색 (#BA1A1A)

#### 2. **`DefeeThemeSizes` 클래스**
앱에서 사용하는 크기 및 여백 설정을 정의한 클래스입니다. `BorderRadius`, `Padding`, `Margin` 등의 크기를 쉽게 관리할 수 있습니다.

- 사용법:
  ```dart
  Container(
    decoration: BoxDecoration(
      borderRadius: DefeeThemeSizes.borderRadius,
    ),
    padding: DefeeThemeSizes.thinPadding,
    margin: DefeeThemeSizes.marginInsets,
  );
  ```

- 주요 설정:
  - `borderRadius`: 기본 모서리 반경 (20.0)
  - `primaryBorderRadius`: 기본의 절반 크기 (10.0)
  - `chipBorderRadius`: 기본의 두 배 크기 (40.0)
  - `padding`: 얇은 여백 (8.0)
  - `thickPadding`: 두꺼운 여백 (16.0)
  - `margin`: 기본 여백 (8.0)

#### 3. `DefeeTextStyles` 클래스
앱에서 사용하는 텍스트 스타일을 정의한 클래스입니다. 다양한 크기와 색상의 텍스트 스타일을 제공합니다.

- 사용법:
  ```dart
  Text('This is Body Text', style: DefeeTextStyles.bodyMedium);
  Text('Primary Button Text', style: DefeeTextStyles.onPrimaryMedium);
  ```

- 주요 스타일:
  - `bodyTiny`, `bodySmall`, `bodyMedium`, `bodyLarge`: 기본 텍스트 스타일 (10pt, 14pt, 18pt, 22pt)
  - `onPrimarySmall`, `onPrimaryMedium`, `onPrimaryLarge`: 밝은 배경에서 사용할 흰색 텍스트 스타일
  - `hint`, `hintSmall`: 힌트 텍스트 스타일 (회색 계열)

#### 4. `AppTheme` 클래스
앱의 테마를 관리하는 클래스입니다. 밝은 테마(`lightTheme`)와 어두운 테마(`darkTheme`)를 제공합니다. 또한, `ColorScheme`을 기반으로 앱의 기본 스타일을 구성합니다.

#### 4.1 **`lightTheme`**
앱의 밝은 테마를 정의합니다. `lightColorScheme`을 사용하여 구성됩니다.
이후에 다크모드 구현을 위해 미리 만들어 두었습니다.

#### 4.2 **`themeData` 메서드**
테마 데이터를 동적으로 생성하는 메서드입니다. `ColorScheme`을 기반으로 커스텀 테마를 만들 수 있습니다.

#### 4.4 **`lightColorScheme`**
앱의 밝은 테마 색상 팔레트입니다.

`lightColorScheme`에 정의된 색상들은 `ThemeData`를 통해 전역적으로 사용하거나, 특정 위젯에서 `Theme.of(context).colorScheme`를 통해 가져와서 사용할 수 있습니다

- `lightColorScheme` 주요 색상
  - `primary`: 주요 색상 (파란색, `#002686`)
  - `onPrimary`: 주요 색상 위에 표시될 텍스트나 아이콘 색상 (흰색, `#FFFFFF`)
  - `secondary`: 보조 색상 (연한 파란색, `#8B8FA8`)
  - `onSecondary`: 보조 색상 위에 표시될 텍스트나 아이콘 색상 (흰색, `#FFFFFF`)
  - `secondaryContainer`: 보조 색상의 밝은 버전 (연보라색, `#D1D8FF`)
  - `onSecondaryContainer`: 보조 색상 컨테이너 위의 텍스트 색상 (짙은 파란색, `#384165`)
  - `surface`: 기본 배경 색상 (아주 연한 보라색, `#FBF8FF`)
  - `onSurface`: 배경 위의 텍스트 색상 (짙은 회색, `#1A1B21`)
  - `surfaceContainer`: 서브 배경 색상 (밝은 회색, `#EEEDF5`)
  - `surfaceDim`: 반투명 배경색 (반투명 검은색, `#44121319`)
  - `outline`: 윤곽선 색상 (중간 회색, `#757683`)
  - `error`: 에러 상태 색상 (빨간색, `#BA1A1A`)
  - `onError`: 에러 상태 텍스트 색상 (흰색, `#FFFFFF`)

- `lightColorScheme` 색상 사용법
1. **앱의 전역 테마에서 사용하기**

```dart
MaterialApp(
  theme: AppTheme.lightTheme,
  home: HomePage(),
);
```

2. 위젯에서 `ColorScheme` 가져와 사용하기
**위젯 내에서 `Theme.of(context).colorScheme`로 `lightColorScheme`의 색상을 가져와 사용할 수 있습니다.**

```dart
Container(
  color: Theme.of(context).colorScheme.primary,
  child: Text(
    'Primary Color Background',
    style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
  ),
);
```
3. **버튼에 적용하기**
`ElevatedButton`, `TextButton` 등에서 `ColorScheme` 색상을 사용해 스타일링할 수 있습니다.

```dart
ElevatedButton(
  style: ElevatedButton.styleFrom(
    backgroundColor: Theme.of(context).colorScheme.secondary,
    foregroundColor: Theme.of(context).colorScheme.onSecondary,
  ),
  onPressed: () {},
  child: Text('Secondary Button'),
);
```
4. **텍스트에 적용하기**
텍스트 위젯에서 색상을 `TextStyle`에 적용할 수 있습니다. 
하지만 웬만하면 `DefeeTextStyle` 클래스로부터 사용해주세요

```dart
Text(
  'Error Message',
  style: TextStyle(
    color: Theme.of(context).colorScheme.error,
  ),
);
```

---
마지막으로 당부드리고 싶은건, 앞으로 어쨌든 색상 주거나 바꿀일 있으면 이미 제가 light theme 적용해놔서 기본 widget들 style은 적용한 대로 들어갈 겁니다. 근데 커스텀해서 사용할 때도 웬만하면 `Color.blue`이렇게 하지 말고 여기 있는 app theme에 있는 스타일 직접 사용하는 것으로 컨벤션 정하는 것이 좋아 보입니다. 

사용하실 때 `import 'package:defeefront/themes/app_theme.dart';` 하셔야 합니다.

onPrimary, primary, secondary, onSecondary 등등이 뭘 의미하는지는 다음 링크를 참고하시면 좋을 것 같습니다.
- https://m3.material.io/styles/color/roles

theme 구성은 다음 블로그를 참고하였습니다.
- https://uzzam.dev/33

**Color의 경우 context가 있는 위젯에서는 꼭 `Theme.of(context).colorScheme.onSecondary`와 같이 사용하고, 없는 경우에만 클래스 직접 사용( ex - `DefeeColors.blue`) 하는걸로 저희끼리 컨벤션 정하는 것으로 하면 좋을 것 같습니다~**
