### PR TITLE
[Feat] signup.dart, header.dart - refix signup page and header widget

### DIFF
--- a/defeefront/lib/screens/headline/widgets/slide_post.dart
+++ b/defeefront/lib/screens/headline/widgets/slide_post.dart
@@ -12,7 +12,7 @@ class SlidePost extends StatelessWidget {
           height: 100,
           child: ListView(
             scrollDirection: Axis.horizontal,
-            children: [
+            children: const [
               SlideItem(),
               SlideItem(),
               SlideItem(),

--- a/defeefront/lib/screens/login/login.dart
+++ b/defeefront/lib/screens/login/login.dart
@@ -1,5 +1,6 @@
 import 'package:defeefront/widgets/basescreen.dart';
 import 'package:defeefront/widgets/input_box.dart';
+import 'package:defeefront/widgets/input_pw_box.dart';
 import 'package:flutter/material.dart';
 
 class Login extends StatefulWidget {
@@ -50,9 +51,8 @@ class _LoginState extends State<Login> {
             ),
             const SizedBox(height: 20),
             // 비밀번호 입력 필드
-            InputBox(
+            InputPwBox(
               labelText: "Password",
-              isPassword: true,
               isPasswordVisible: _isPasswordVisible,
               togglePasswordVisibility: () {
                 setState(() {

--- a/defeefront/lib/screens/signup/signup.dart
+++ b/defeefront/lib/screens/signup/signup.dart
@@ -1,4 +1,6 @@
 import 'package:defeefront/widgets/input_box.dart';
+import 'package:defeefront/widgets/input_btn_box.dart';
+import 'package:defeefront/widgets/input_pw_box.dart';
 import 'package:flutter/material.dart';
 
 class Signup extends StatefulWidget {
@@ -13,6 +15,7 @@ class _SignupState extends State<Signup> {
   bool _isConfirmPasswordVisible = false;
 
   final TextEditingController emailController = TextEditingController();
+  final TextEditingController codeController = TextEditingController();
   final TextEditingController usernameController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
   final TextEditingController confirmPasswordController =
@@ -46,17 +49,25 @@ class _SignupState extends State<Signup> {
                 SizedBox(height: 30),
               ],
             ),
-            InputBox(
+            InputBtnBox(
               labelText: "E-Mail",
               controller: emailController,
+              buttonText: "확인",
             ),
             const SizedBox(height: 10),
-            InputBox(
+            InputBtnBox(
+              labelText: "Code",
+              controller: codeController,
+              buttonText: "인증",
+            ),
+            const SizedBox(height: 10),
+            InputBtnBox(
               labelText: "Username",
               controller: usernameController,
+              buttonText: "확인",
             ),
             const SizedBox(height: 10),
-            InputBox(
+            InputPwBox(
               labelText: "Password",
               isPassword: true,
               isPasswordVisible: _isPasswordVisible,
@@ -68,7 +79,7 @@ class _SignupState extends State<Signup> {
               controller: passwordController,
             ),
             const SizedBox(height: 10),
-            InputBox(
+            InputPwBox(
               labelText: "Confirm",
               isPassword: true,
               isPasswordVisible: _isConfirmPasswordVisible,

--- a/defeefront/lib/screens/signup/signup.dart
+++ b/defeefront/lib/screens/signup/signup.dart
@@ -13,6 +13,8 @@ class Signup extends StatefulWidget {
 class _SignupState extends State<Signup> {
   bool _isPasswordVisible = false;
   bool _isConfirmPasswordVisible = false;
+  bool _isFormValid = false;
+  bool _isEmailVerified = false;
 
   final TextEditingController emailController = TextEditingController();
   final TextEditingController codeController = TextEditingController();
@@ -23,10 +25,109 @@ class _SignupState extends State<Signup> {
   final TextEditingController blogLinkController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+
+    // 입력값 변경 감지
+    emailController.addListener(_validateForm);
+    codeController.addListener(_validateForm);
+    usernameController.addListener(_validateForm);
+    passwordController.addListener(_validateForm);
+    confirmPasswordController.addListener(_validateForm);
+    blogLinkController.addListener(_validateForm);
+  }
+
+  @override
+  void dispose() {
+    // 컨트롤러 해제
+    emailController.dispose();
+    codeController.dispose();
+    usernameController.dispose();
+    passwordController.dispose();
+    confirmPasswordController.dispose();
+    blogLinkController.dispose();
+    super.dispose();
+  }
+
+  void _validateForm() {
+    setState(() {
+      _isFormValid = emailController.text.isNotEmpty &&
+          (_isEmailVerified ? codeController.text.isNotEmpty : true) &&
+          usernameController.text.isNotEmpty &&
+          passwordController.text.isNotEmpty &&
+          confirmPasswordController.text.isNotEmpty &&
+          passwordController.text == confirmPasswordController.text;
+    });
+  }
+
+  // 이메일 전송
+  void _sendEmail() {
+    final email = emailController.text;
+    final emailRegExp =
+        RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+
+    if (email.isEmpty) {
+      print("이메일을 입력해주세요.");
+      return;
+    } else if (!emailRegExp.hasMatch(email)) {
+      print("올바른 이메일 형식이 아닙니다.");
+      return;
+    }
+
+    setState(() {
+      _isEmailVerified = true;
+    });
+
+    print("이메일 전송: $email");
+  }
+
+  // 코드 인증
+  void _verifyCode() {
+    final code = codeController.text;
+
+    if (code.isEmpty) {
+      print("코드를 입력해주세요.");
+      return;
+    }
+
+    print("코드 인증: $code");
+  }
+
+  // 닉네임 중복체크
+  void _checkUsername() {
+    final username = usernameController.text;
+
+    if (username.isEmpty) {
+      print("유저네임을 입력해주세요.");
+      return;
+    }
+
+    print("유저네임 체크: $username");
+  }
+
+  void _onSignUp() {
+    if (!_isFormValid) return;
+
+    final email = emailController.text;
+    final code = codeController.text;
+    final username = usernameController.text;
+    final password = passwordController.text;
+    final blogLink = blogLinkController.text;
+
+    print("E-mail: $email");
+    print("Code: $code");
+    print("Username: $username");
+    print("Password: $password");
+    print("Blog Link: $blogLink");
+
+    print("회원가입 성공!");
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Padding(
-        padding: const EdgeInsets.all(30.0),
+        padding: const EdgeInsets.all(40.0),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -52,24 +153,31 @@ class _SignupState extends State<Signup> {
             InputBtnBox(
               labelText: "E-Mail",
               controller: emailController,
-              buttonText: "확인",
+              buttonText: "전송",
+              onButtonPressed: _sendEmail,
+              isButtonEnabled: emailController.text.isNotEmpty,
             ),
             const SizedBox(height: 10),
-            InputBtnBox(
-              labelText: "Code",
-              controller: codeController,
-              buttonText: "인증",
-            ),
-            const SizedBox(height: 10),
+            if (_isEmailVerified) ...[
+              InputBtnBox(
+                labelText: "Code",
+                controller: codeController,
+                buttonText: "인증",
+                onButtonPressed: _verifyCode,
+                isButtonEnabled: codeController.text.isNotEmpty,
+              ),
+              const SizedBox(height: 10),
+            ],
             InputBtnBox(
               labelText: "Username",
               controller: usernameController,
-              buttonText: "확인",
+              buttonText: "체크",
+              onButtonPressed: _checkUsername,
+              isButtonEnabled: usernameController.text.isNotEmpty,
             ),
             const SizedBox(height: 10),
             InputPwBox(
               labelText: "Password",
-              isPassword: true,
               isPasswordVisible: _isPasswordVisible,
               togglePasswordVisibility: () {
                 setState(() {
@@ -81,7 +189,6 @@ class _SignupState extends State<Signup> {
             const SizedBox(height: 10),
             InputPwBox(
               labelText: "Confirm",
-              isPassword: true,
               isPasswordVisible: _isConfirmPasswordVisible,
               togglePasswordVisibility: () {
                 setState(() {
@@ -97,12 +204,11 @@ class _SignupState extends State<Signup> {
             ),
             const SizedBox(height: 30),
             ElevatedButton(
-              onPressed: () {
-                print("회원가입 버튼 클릭");
-              },
+              onPressed: _isFormValid ? _onSignUp : null,
               style: ElevatedButton.styleFrom(
-                minimumSize: const Size(300, 50),
+                minimumSize: const Size(350, 50),
                 backgroundColor: const Color.fromARGB(200, 0, 38, 134),
+                disabledBackgroundColor: Colors.grey,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(8.0),
                 ),

--- a/defeefront/lib/widgets/header.dart
+++ b/defeefront/lib/widgets/header.dart
@@ -5,25 +5,56 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentRoute = ModalRoute.of(context)?.settings.name;
+
+    String headerText;
+    switch (currentRoute) {
+      case '/search':
+        headerText = "검색";
+        break;
+      case '/recommend':
+        headerText = "추천";
+        break;
+      case '/my':
+        headerText = "MY";
+        break;
+      default:
+        headerText = "헤드라인";
+    }
+
     return AppBar(
       centerTitle: true,
-      leading: IconButton(
-        icon: Icon(
-          Icons.arrow_back_ios_new,
-          color: Colors.indigo[900],
-          size: 24,
-        ),
-        onPressed: () {
-          Navigator.pop(context);
-        },
-      ),
+      leading: null,
       title: Text(
-        "헤드라인",
+        headerText,
         style: TextStyle(
-            color: Colors.indigo[900],
-            fontWeight: FontWeight.bold,
-            fontSize: 24),
+          color: Colors.indigo[900],
+          fontWeight: FontWeight.bold,
+          fontSize: 24,
+        ),
       ),
+      backgroundColor: Colors.white,
+      elevation: 0,
+      actions: [
+        IconButton(
+          icon: Icon(
+            Icons.notifications,
+            color: Colors.indigo[900],
+          ),
+          onPressed: () {
+            print("알림 아이콘 클릭됨");
+          },
+        ),
+        IconButton(
+          icon: Icon(
+            Icons.menu,
+            color: Colors.indigo[900],
+          ),
+          onPressed: () {
+            print("목록 아이콘 클릭됨");
+          },
+        ),
+      ],
     );
   }
 

--- a/defeefront/lib/widgets/input_box.dart
+++ b/defeefront/lib/widgets/input_box.dart
@@ -2,17 +2,11 @@ import 'package:flutter/material.dart';
 
 class InputBox extends StatelessWidget {
   final String labelText;
-  final bool isPassword;
-  final bool isPasswordVisible;
-  final void Function()? togglePasswordVisibility;
   final TextEditingController? controller;
 
   const InputBox({
     super.key,
     required this.labelText,
-    this.isPassword = false,
-    this.isPasswordVisible = false,
-    this.togglePasswordVisibility,
     this.controller,
   });
 
@@ -20,51 +14,37 @@ class InputBox extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Align(
-          alignment: Alignment.centerRight,
-          child: SizedBox(
-            width: 80,
-            child: Text(
-              "$labelText :",
-              style: const TextStyle(
-                fontSize: 13,
-                color: Color.fromARGB(255, 97, 97, 97),
-              ),
-              textAlign: TextAlign.end,
+        SizedBox(
+          width: 80,
+          child: Text(
+            "$labelText :",
+            style: const TextStyle(
+              fontSize: 13,
+              color: Color.fromARGB(255, 97, 97, 97),
             ),
+            textAlign: TextAlign.end,
           ),
         ),
         const SizedBox(width: 10),
-        Align(
-          alignment: Alignment.centerLeft,
-          child: SizedBox(
-            width: 200,
-            child: TextFormField(
-              controller: controller,
-              obscureText: isPassword && !isPasswordVisible,
-              decoration: InputDecoration(
-                contentPadding: const EdgeInsets.symmetric(vertical: 15.0),
-                isDense: true,
-                border: const UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: Color.fromARGB(255, 97, 97, 97),
-                  ),
+        Expanded(
+          child: TextFormField(
+            controller: controller,
+            decoration: const InputDecoration(
+              contentPadding: EdgeInsets.symmetric(vertical: 15.0),
+              isDense: true,
+              border: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: Color.fromARGB(255, 97, 97, 97),
                 ),
-                suffixIcon: isPassword
-                    ? IconButton(
-                        icon: Icon(
-                          isPasswordVisible
-                              ? Icons.visibility
-                              : Icons.visibility_off,
-                        ),
-                        onPressed: togglePasswordVisibility,
-                      )
-                    : null,
               ),
             ),
           ),
         ),
+        SizedBox(
+          width: 50,
+        )
       ],
     );
   }

--- a/defeefront/lib/widgets/input_btn_box.dart
+++ b/defeefront/lib/widgets/input_btn_box.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 class InputBtnBox extends StatelessWidget {
   final String labelText;
   final String buttonText;
+  final bool isButtonEnabled;
   final void Function()? onButtonPressed;
   final TextEditingController? controller;
 
@@ -10,6 +11,7 @@ class InputBtnBox extends StatelessWidget {
     super.key,
     required this.labelText,
     required this.buttonText,
+    required this.isButtonEnabled,
     this.onButtonPressed,
     this.controller,
   });
@@ -48,10 +50,12 @@ class InputBtnBox extends StatelessWidget {
         ),
         const SizedBox(width: 10),
         ElevatedButton(
-          onPressed: onButtonPressed,
+          onPressed: isButtonEnabled ? onButtonPressed : null,
           style: ElevatedButton.styleFrom(
             minimumSize: const Size(70, 40),
-            backgroundColor: const Color.fromARGB(255, 0, 122, 255),
+            backgroundColor: isButtonEnabled
+                ? const Color.fromARGB(255, 0, 122, 255)
+                : Colors.grey,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8.0),
             ),

--- a/defeefront/lib/widgets/input_btn_box.dart
+++ b/defeefront/lib/widgets/input_btn_box.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class InputBtnBox extends StatelessWidget {
+  final String labelText;
+  final String buttonText;
+  final void Function()? onButtonPressed;
+  final TextEditingController? controller;
+
+  const InputBtnBox({
+    super.key,
+    required this.labelText,
+    required this.buttonText,
+    this.onButtonPressed,
+    this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 80,
+          child: Text(
+            "$labelText :",
+            style: const TextStyle(
+              fontSize: 13,
+              color: Color.fromARGB(255, 97, 97, 97),
+            ),
+            textAlign: TextAlign.end,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: TextFormField(
+            controller: controller,
+            decoration: const InputDecoration(
+              contentPadding: EdgeInsets.symmetric(vertical: 15.0),
+              isDense: true,
+              border: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: Color.fromARGB(255, 97, 97, 97),
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        ElevatedButton(
+          onPressed: onButtonPressed,
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size(70, 40),
+            backgroundColor: const Color.fromARGB(255, 0, 122, 255),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+          ),
+          child: Text(
+            buttonText,
+            style: const TextStyle(color: Colors.white, fontSize: 13),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/defeefront/lib/widgets/input_pw_box.dart
+++ b/defeefront/lib/widgets/input_pw_box.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class InputPwBox extends StatelessWidget {
+  final String labelText;
+  final bool isPasswordVisible;
+  final void Function()? togglePasswordVisibility;
+  final TextEditingController? controller;
+
+  const InputPwBox({
+    super.key,
+    required this.labelText,
+    required this.isPasswordVisible,
+    this.togglePasswordVisibility,
+    this.controller,
+    required bool isPassword,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 80,
+          child: Text(
+            "$labelText :",
+            style: const TextStyle(
+              fontSize: 13,
+              color: Color.fromARGB(255, 97, 97, 97),
+            ),
+            textAlign: TextAlign.end,
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: TextFormField(
+            controller: controller,
+            obscureText: !isPasswordVisible,
+            decoration: InputDecoration(
+              contentPadding: const EdgeInsets.symmetric(vertical: 15.0),
+              isDense: true,
+              border: const UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: Color.fromARGB(255, 97, 97, 97),
+                ),
+              ),
+              suffixIcon: IconButton(
+                icon: Icon(
+                  isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+                ),
+                onPressed: togglePasswordVisibility,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/defeefront/lib/widgets/input_pw_box.dart
+++ b/defeefront/lib/widgets/input_pw_box.dart
@@ -12,7 +12,6 @@ class InputPwBox extends StatelessWidget {
     required this.isPasswordVisible,
     this.togglePasswordVisibility,
     this.controller,
-    required bool isPassword,
   });
 
   @override
@@ -37,22 +36,23 @@ class InputPwBox extends StatelessWidget {
           child: TextFormField(
             controller: controller,
             obscureText: !isPasswordVisible,
-            decoration: InputDecoration(
-              contentPadding: const EdgeInsets.symmetric(vertical: 15.0),
+            decoration: const InputDecoration(
+              contentPadding: EdgeInsets.symmetric(vertical: 15.0),
               isDense: true,
-              border: const UnderlineInputBorder(
+              border: UnderlineInputBorder(
                 borderSide: BorderSide(
                   color: Color.fromARGB(255, 97, 97, 97),
                 ),
               ),
-              suffixIcon: IconButton(
-                icon: Icon(
-                  isPasswordVisible ? Icons.visibility : Icons.visibility_off,
-                ),
-                onPressed: togglePasswordVisibility,
-              ),
             ),
           ),
+        ),
+        const SizedBox(width: 10), // 입력창과 아이콘 간의 간격
+        IconButton(
+          icon: Icon(
+            isPasswordVisible ? Icons.visibility : Icons.visibility_off,
+          ),
+          onPressed: togglePasswordVisibility,
         ),
       ],
     );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용

> 회원가입 UI 수정
> 회원가입 인증 코드 입력 추가
> 이메일 전송 버튼 클릭 시 코드 입력창 생성
> 버튼 입력창, 비밀번호 입력창, 일반 입력창 세 가지 위젯으로 분리
> 헤더의 텍스트를 현재 경로에 따라 동적으로 변경
> 뒤로가기 버튼 삭제
> 알람 아이콘과 설정 아이콘 추가

## 💬리뷰 요구사항(선택)

> 헤더 부분에 적용했던 app theme 코드와 수정한 코드가 충돌했으나 app theme까지 적용한 걸로 올렸습니다. 기존 코드와 비교해서 확인은 다 했는데 혹시 지워진 부분이 있을 수도 있어서 코드 한번만 확인 부탁드립니다.