### PR TITLE
[Feat] settings.dart - add setting page

### DIFF
--- a/defeefront/lib/routes.dart
+++ b/defeefront/lib/routes.dart
@@ -5,6 +5,8 @@ import 'package:defeefront/screens/recommend/recommend.dart';
 import 'package:defeefront/screens/search/search.dart';
 import 'package:defeefront/screens/search_result/search_result.dart';
 import 'package:defeefront/screens/signup/signup.dart';
+import 'package:defeefront/screens/settings/settings.dart';
+
 import 'package:flutter/material.dart';
 
 final routes = {
@@ -15,4 +17,5 @@ final routes = {
   '/searchresult': (BuildContext context) => SearchResult(),
   '/recommend': (BuildContext context) => Recommend(),
   '/my': (BuildContext context) => const MyPage(),
+  '/settings': (BuildContext context) => Settings(),
 };

--- a/defeefront/lib/screens/settings/settings.dart
+++ b/defeefront/lib/screens/settings/settings.dart
@@ -1,7 +1,6 @@
-import 'package:defeefront/widgets/footer.dart';
+import 'package:defeefront/screens/settings/widget/setting_content.dart';
 import 'package:flutter/material.dart';
 import 'package:defeefront/themes/app_theme.dart';
-import 'package:defeefront/widgets/header.dart';
 
 class Settings extends StatelessWidget {
   const Settings({Key? key}) : super(key: key);
@@ -9,19 +8,18 @@ class Settings extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: Header(),
-      body: Container(
-        color: Theme.of(context).colorScheme.surfaceContainer,
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Column(
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
-                borderRadius: DefeeThemeSizes.borderRadius,
-              ),
+      appBar: AppBar(title: Text("설정")),
+      body: SafeArea(
+        child: Container(
+          color: Theme.of(context).colorScheme.surface,
+          padding: EdgeInsets.symmetric(horizontal: 20),
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                SettingContent(),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/defeefront/lib/screens/settings/settings.dart
+++ b/defeefront/lib/screens/settings/settings.dart
@@ -1,0 +1,29 @@
+import 'package:defeefront/widgets/footer.dart';
+import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
+import 'package:defeefront/widgets/header.dart';
+
+class Settings extends StatelessWidget {
+  const Settings({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: Header(),
+      body: Container(
+        color: Theme.of(context).colorScheme.surfaceContainer,
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: DefeeThemeSizes.borderRadius,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/defeefront/lib/screens/settings/widget/setting_content.dart
+++ b/defeefront/lib/screens/settings/widget/setting_content.dart
@@ -1,0 +1,33 @@
+import 'package:defeefront/screens/settings/widget/setting_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
+
+class SettingContent extends StatelessWidget {
+  const SettingContent({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Theme.of(context).colorScheme.surface,
+      child: Column(
+        children: [
+          SettingMenu(title: "계정", menuItems: ["닉네임 변경", "블로그 변경"]),
+          SettingMenu(title: "시스템 설정", menuItems: ["알림 설정", "다크/라이트모드 설정"]),
+          SettingMenu(title: "기타", menuItems: ["문의 및 피드백", "앱 공유하기"]),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(height: 20),
+              Text("버전 1.0.0 | 로그아웃",
+                  style: Theme.of(context).textTheme.bodySmall),
+              SizedBox(height: 8),
+              Text("개인정보 처리방침 | 이용약관",
+                  style: Theme.of(context).textTheme.bodySmall),
+              SizedBox(height: 20),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/defeefront/lib/screens/settings/widget/setting_content.dart
+++ b/defeefront/lib/screens/settings/widget/setting_content.dart
@@ -11,9 +11,47 @@ class SettingContent extends StatelessWidget {
       color: Theme.of(context).colorScheme.surface,
       child: Column(
         children: [
-          SettingMenu(title: "계정", menuItems: ["닉네임 변경", "블로그 변경"]),
-          SettingMenu(title: "시스템 설정", menuItems: ["알림 설정", "다크/라이트모드 설정"]),
-          SettingMenu(title: "기타", menuItems: ["문의 및 피드백", "앱 공유하기"]),
+          SettingMenu(
+            title: "계정",
+            menuItems: [
+              {
+                'title': '닉네임 변경',
+                'onTap': () =>
+                    {print('닉네임 변경 클릭'), Navigator.pushNamed(context, '/login')}
+              },
+              {'title': '블로그 변경', 'onTap': () => print('블로그 변경 클릭')},
+            ],
+          ),
+          SettingMenu(
+            title: "시스템 설정",
+            menuItems: [
+              {
+                'title': '알림 설정',
+                'onTap': () => print('알림 설정 클릭'),
+                // 'onTap': () => Navigator.push(context, MaterialPageRoute(builder: (context) => NotificationSettingsPage())),
+              },
+              {
+                'title': '다크/라이트모드 설정',
+                'onTap': () => print('다크/라이트모드 설정 클릭'),
+              },
+            ],
+          ),
+          SettingMenu(
+            title: "기타",
+            menuItems: [
+              {
+                'title': '문의 및 피드백',
+                'onTap': () => print('문의 및 피드백 클릭'),
+                // 'onTap': () => Navigator.push(context, MaterialPageRoute(builder: (context) => FeedbackPage())),
+              },
+              {
+                'title': '앱 공유하기',
+                'onTap': () {
+                  print('앱 공유하기 클릭');
+                },
+              },
+            ],
+          ),
           Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [

--- a/defeefront/lib/screens/settings/widget/setting_menu.dart
+++ b/defeefront/lib/screens/settings/widget/setting_menu.dart
@@ -3,7 +3,7 @@ import 'package:defeefront/themes/app_theme.dart';
 
 class SettingMenu extends StatelessWidget {
   final String title;
-  final List<String> menuItems;
+  final List<Map<String, dynamic>> menuItems; // Map 구조로 변경
 
   SettingMenu({required this.title, required this.menuItems});
 
@@ -23,17 +23,18 @@ class SettingMenu extends StatelessWidget {
           ),
           child: Column(
             children: menuItems
-                .map((item) => Column(
+                .map((menuItem) => Column(
                       children: [
                         ListTile(
                           title: Text(
-                            item,
+                            menuItem['title'],
                             style: DefeeTextStyles.onPrimaryLarge,
                           ),
                           trailing: Icon(Icons.arrow_forward_ios,
                               color: Theme.of(context).colorScheme.onPrimary),
+                          onTap: menuItem['onTap'], // 각 메뉴의 onTap 함수 실행
                         ),
-                        if (menuItems.indexOf(item) != menuItems.length - 1)
+                        if (menuItems.indexOf(menuItem) != menuItems.length - 1)
                           Divider(),
                       ],
                     ))

--- a/defeefront/lib/screens/settings/widget/setting_menu.dart
+++ b/defeefront/lib/screens/settings/widget/setting_menu.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:defeefront/themes/app_theme.dart';
+
+class SettingMenu extends StatelessWidget {
+  final String title;
+  final List<String> menuItems;
+
+  SettingMenu({required this.title, required this.menuItems});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(height: 20),
+        Text(title, style: Theme.of(context).textTheme.bodyLarge),
+        SizedBox(height: 20),
+        Container(
+          padding: EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primary,
+            borderRadius: DefeeThemeSizes.primaryBorderRadius,
+          ),
+          child: Column(
+            children: menuItems
+                .map((item) => Column(
+                      children: [
+                        ListTile(
+                          title: Text(
+                            item,
+                            style: DefeeTextStyles.onPrimaryLarge,
+                          ),
+                          trailing: Icon(Icons.arrow_forward_ios,
+                              color: Theme.of(context).colorScheme.onPrimary),
+                        ),
+                        if (menuItems.indexOf(item) != menuItems.length - 1)
+                          Divider(),
+                      ],
+                    ))
+                .toList(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/defeefront/lib/widgets/header.dart
+++ b/defeefront/lib/widgets/header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:defeefront/screens/settings/settings.dart';
 
 class Header extends StatelessWidget implements PreferredSizeWidget {
   const Header({super.key});
@@ -18,6 +19,9 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
       case '/my':
         headerText = "MY";
         break;
+      case '/settings':
+        headerText = "설정";
+        break;
       default:
         headerText = "헤드라인";
     }
@@ -31,7 +35,7 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
           color: Theme.of(context).colorScheme.primary,
         ),
       ),
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
       elevation: 0,
       actions: [
         IconButton(
@@ -49,7 +53,7 @@ class Header extends StatelessWidget implements PreferredSizeWidget {
             color: Theme.of(context).colorScheme.primary,
           ),
           onPressed: () {
-            print("목록 아이콘 클릭됨");
+            Navigator.pushNamed(context, '/settings');
           },
         ),
       ],


### PR DESCRIPTION
## #️⃣연관된 이슈

#22 

## 📝작업 내용
### `settings.dart`
하단 navbar가 없는 페이지를 구현하기 위해 `SafeArea`를 사용하여 구현하였습니다.
- `setting_content.dart`
body 부분에 해당합니다.
- `setting_menu.dart`
각각의 메뉴에 대한 widget입니다.

### `header.dart`
헤더의 탭바에 대한 onPress 시 navigator를 구현하였습니다.


---

This pull request introduces a new settings page to the application and integrates it into the existing navigation system. The most important changes include adding the settings page, updating the routes, and modifying the header widget to support the new page.

### New Settings Page:

* [`defeefront/lib/screens/settings/settings.dart`](diffhunk://#diff-cb85a1dba65bf1e3474f8581103be71163f1bd1920a1631874a3d18fc9d9783fR1-R27): Created a new `Settings` page with a scaffold, app bar, and body containing `SettingContent`.
* [`defeefront/lib/screens/settings/widget/setting_content.dart`](diffhunk://#diff-685d97e0c5be29ed5734a060f864ac5fbdd789e4488788a2994764a5006da0e1R1-R71): Added `SettingContent` widget, which includes various settings options like account settings and system settings.
* [`defeefront/lib/screens/settings/widget/setting_menu.dart`](diffhunk://#diff-18378f7cae0ee9cff766511fbfbdcf4a9e8d3fa82ac4ff9d4d3f891d601fe1f4R1-R47): Added `SettingMenu` widget to display individual setting options with titles and actions.

### Route and Navigation Updates:

* [`defeefront/lib/routes.dart`](diffhunk://#diff-75ac1c1f36e18a75d2db5ec43295788215df3168cd9243f8c1d43b8f893ca5d7R8-R9): Added the settings page to the routes map and imported the settings page. [[1]](diffhunk://#diff-75ac1c1f36e18a75d2db5ec43295788215df3168cd9243f8c1d43b8f893ca5d7R8-R9) [[2]](diffhunk://#diff-75ac1c1f36e18a75d2db5ec43295788215df3168cd9243f8c1d43b8f893ca5d7R20)
* [`defeefront/lib/widgets/header.dart`](diffhunk://#diff-c8960cd527b815818f5bba4cf7121e6b06c89583eb59b6e93c5ebfe9b0168b55R2): Updated the header widget to recognize the settings route and navigate to it when the settings icon is clicked. [[1]](diffhunk://#diff-c8960cd527b815818f5bba4cf7121e6b06c89583eb59b6e93c5ebfe9b0168b55R2) [[2]](diffhunk://#diff-c8960cd527b815818f5bba4cf7121e6b06c89583eb59b6e93c5ebfe9b0168b55R22-R24) [[3]](diffhunk://#diff-c8960cd527b815818f5bba4cf7121e6b06c89583eb59b6e93c5ebfe9b0168b55L34-R38) [[4]](diffhunk://#diff-c8960cd527b815818f5bba4cf7121e6b06c89583eb59b6e93c5ebfe9b0168b55L52-R56)